### PR TITLE
Pass NULL pointer as second argument to realpath

### DIFF
--- a/src/utilities.c
+++ b/src/utilities.c
@@ -301,7 +301,7 @@ IOR_offset_t StringToBytes(char *size_str)
 void ShowFileSystemSize(char *fileSystem)
 {
 #ifndef _WIN32                  /* FIXME */
-        char realPath[PATH_MAX];
+        char *realPath;
         char *fileSystemUnitStr;
         long long int totalFileSystemSize;
         long long int freeFileSystemSize;
@@ -352,7 +352,8 @@ void ShowFileSystemSize(char *fileSystem)
             (1 - ((double)freeInodes / (double)totalInodes)) * 100;
 
         /* show results */
-        if (realpath(fileSystem, realPath) == NULL) {
+	realPath = realpath(fileSystem, NULL);
+        if (realPath == NULL) {
                 ERR("unable to use realpath()");
         }
         fprintf(stdout, "Path: %s\n", realPath);


### PR DESCRIPTION
Pass NULL pointer as second argument to realpath. Avoids buffer overflow error. This is standard behavior as of POSIX 2008

Running on Ubuntu AWS EC2, same error on my local WS Ubuntu:

    IOR-2.10.3: MPI Coordinated Test of Parallel I/O
    
    Run began: Tue Jun 23 10:50:08 2015
    Command line used: ./IOR -f N8TrinityScript
    Machine: Linux ip-172-30-0-114 3.13.0-48-generic #80-Ubuntu SMP Thu Mar 12 11:16:15 UTC 2015 x86_64
    Using synchronized MPI timer
    Start time skew across all tasks: 0.00 sec
    *** buffer overflow detected ***: ./IOR terminated
    ======= Backtrace: =========
    /lib/x86_64-linux-gnu/libc.so.6(+0x7338f)[0x7f3c9ecc738f]
    /lib/x86_64-linux-gnu/libc.so.6(__fortify_fail+0x5c)[0x7f3c9ed5ec9c]
    /lib/x86_64-linux-gnu/libc.so.6(+0x109b60)[0x7f3c9ed5db60]
    /lib/x86_64-linux-gnu/libc.so.6(+0x10a0f4)[0x7f3c9ed5e0f4]
    ./IOR[0x40f612]
    ....

Where ./IOR[0x40f612] points to the changed line in utilities.c.